### PR TITLE
Vagrantfile: Add -ffernandes do domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,54 @@
+# devmaster
+## Fedora users
+Installing the basic:
+```
+$ sudo dnf install @vagrant
+```
+
+Installing the recommended vagrant plugins:
+```
+$ vagrant plugin install vagrant-hostmanager vagrant-libvirt vagrant-sshfs vagrant-ssh
+```
+
+To verify all plugins are installed:
+```
+$ vagrant plugin list
+vagrant-hostmanager (1.8.9, global)
+vagrant-libvirt (0.4.1, system)
+vagrant-ssh (2.1.0, global)
+vagrant-sshfs (1.3.6, global)
+```
+
+## Using bridge mode
+Flavio's fork adds the `bridge mode` support. 
+
+On **Linux machines** the `default bridge name` is `virbr0` but users are free to change. Assuming users will use `virbr0` please change the following:
+
+```
+--- a/Vagrantfile
++++ b/Vagrantfile
+@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
+         "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]
+   end
+   config.vm.network "public_network",
+-                    :dev => "bridge0",
++                    :dev => "virbr0",
+                     :mode => "bridge",
+                     :type => "bridge"
+```
+
+On top of that, make sure to set the proper permission to the user that will run the `vagrant up`
+```
+echo "allow all" | sudo tee /etc/qemu/${USER}.conf
+echo "include /etc/qemu/${USER}.conf" | sudo tee --append /etc/qemu/bridge.conf
+sudo chown root:${USER} /etc/qemu/${USER}.conf
+sudo chmod 640 /etc/qemu/${USER}.conf
+```
+
+After that `vagrant up` should work out of box.
+
+```
+$ git clone https://github.com/flavio-fernandes/devmaster && cd devmaster
+$ vagrant up
+```
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,7 +31,7 @@ Vagrant.configure("2") do |config|
   config.hostmanager.manage_host = true
   config.hostmanager.manage_guest = true
   config.ssh.forward_agent = true
-  config.vm.define "devmaster" do |node|
+  config.vm.define "devmaster-ffernandes" do |node|
     node.vm.hostname = "devmaster"
     if ENV['VM_MOUNT_NFS']
       node.vm.synced_folder "#{ENV['PWD']}", "/vagrant", type: "nfs",


### PR DESCRIPTION
Today if users try to run Flavio's fork and jcaamano at
the same machine it will complain the devmaster_devmaster domain
already exists. This patch workaround that.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>